### PR TITLE
Disallow attacking owner when playerAllowAttackOwner is false

### DIFF
--- a/src/main/java/org/jlortiz/playercollars/PlayerCollarsMod.java
+++ b/src/main/java/org/jlortiz/playercollars/PlayerCollarsMod.java
@@ -300,12 +300,17 @@ public class PlayerCollarsMod implements ModInitializer {
 
 			ServerWorld sworld = (ServerWorld) world;
 			AccessoriesCapability cap = AccessoriesCapability.get(player);
-			if (cap != null && sworld.getGameRules().getBoolean(ALLOW_ATTACK_OWNER)) {
+			if (cap != null) {
 				for (SlotEntryReference sr : cap.getEquipped((x) -> x.isIn(PlayerCollarsMod.COLLAR_TAG))) {
 					OwnerComponent owner = sr.stack().get(OWNER_COMPONENT_TYPE);
 					if (owner != null && owner.uuid().equals(entity.getUuid())) {
 						// Collared players are allowed to attack owners, but have 75% damage returned to them
 						player.sendMessage(Text.translatable("message.playercollars.no_attack_owner").formatted(Formatting.RED), true);
+
+						if (!sworld.getGameRules().getBoolean(ALLOW_ATTACK_OWNER)) {
+							return ActionResult.FAIL;
+						}
+
 						double f = player.getAttributeValue(EntityAttributes.ATTACK_DAMAGE);
 						f = (f - 1) * 0.75 + 1;
 						player.damage(sworld, player.getDamageSources().playerAttack(player), (float) Math.ceil(f));


### PR DESCRIPTION
The game rule `playerAllowAttackOwner` currently doesn't do what it says on the tin -- it determines whether or not the pet gets damage reflected back at them when they attack their owner.

This PR makes that gamerule instead control whether or not the pet is allowed to damage their owner at all.